### PR TITLE
[WIP] Refactor dependencies retrieval

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'pkgwat'
 gem 'bicho'
 gem 'ruby-bugzilla'
 gem 'text'
+gem 'awesome_spawn'
 
 gem 'whenever', :require => false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,7 @@ GEM
     arel (4.0.2)
     ast (2.0.0)
     awesome_print (1.2.0)
+    awesome_spawn (1.2.1)
     bicho (0.0.6)
       highline (~> 1.6.2)
       inifile (~> 0.4.1)
@@ -355,6 +356,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
+  awesome_spawn
   bicho
   bootstrap-sass
   bootstrap-will_paginate

--- a/app/models/fedora_rpm.rb
+++ b/app/models/fedora_rpm.rb
@@ -202,7 +202,8 @@ class FedoraRpm < ActiveRecord::Base
     dependencies.clear
 
     # Runtime (Requires)
-    cmd = `repoquery --repoid=rawhide --requires --resolve #{name} --qf="%{NAME}"`
+    query = "repoquery --repoid=rawhide --requires --resolve #{name} --qf=\"%{NAME}\""
+    cmd = AwesomeSpawn.run(query).output
     cmd.lines.map(&:chomp).select { |v| v.start_with? 'rubygem-' }.each do |line|
       d = Dependency.new
       d.dependent = line.split('-', 2).last


### PR DESCRIPTION
See #17 

There is no way at this point to fetch the information via an API. We have to use `repoquery` instead. That limits us to production OS running Fedora though.

TODO
- [ ] Mark the environment column as `dev/runtime` if a dependency is both runtime/development.
- [ ] Split runtime and development dependencies in separate methods
- [ ] Add tests
